### PR TITLE
Specify license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "This is an alternative port of Coda Hale's metrics library.",
   "version": "0.1.5",
   "homepage": "https://github.com/felixge/node-measured",
+  "license": "MIT",
   "repository": {
     "url": "git://github.com/felixge/node-measured.git"
   },


### PR DESCRIPTION
The README already says that this project uses the MIT license. This simply makes that information available to services like [npmjs.org][1].

[1]: https://www.npmjs.org/package/measured