### PR TITLE
Browserify support, testing in browsers and linting

### DIFF
--- a/.jslintrc
+++ b/.jslintrc
@@ -1,0 +1,8 @@
+{
+  "indent"   : 2,
+  "maxlen"   : 79,
+  "node"     : true,
+  "plusplus" : true,
+  "vars"     : true,
+  "nomen"    : true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - 0.4
-  - 0.6
+  - 0.10

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
-NODE = node
+NPM = npm
 
 test:
-	@$(NODE) ./test/run.js
+	@$(NPM) test
 
 .PHONY: test

--- a/example/http_requests_per_second.js
+++ b/example/http_requests_per_second.js
@@ -1,14 +1,16 @@
+'use strict';
+
 var metrics    = require('..');
 var collection = new metrics.Collection('http');
 var http       = require('http');
 
 var rps = collection.meter('requestsPerSecond');
-http.createServer(function(req, res) {
+http.createServer(function (req, res) {
   console.error(req.headers['content-length']);
   rps.mark();
   res.end('Thanks');
-}).listen(3000);
+}).listen(8000);
 
-setInterval(function() {
+setInterval(function () {
   console.log(collection.toJSON());
 }, 1000);

--- a/index.js
+++ b/index.js
@@ -1,15 +1,24 @@
-var Collection = exports.Collection = require('./lib/Collection');
+'use strict';
 
+var Collection = require('./lib/Collection');
 var metrics = require('./lib/metrics');
-for (var name in metrics) {
-  exports[name] = metrics[name];
-}
-
 var util = require('./lib/util');
-for (var name in util) {
-  exports[name] = util[name];
+
+var name;
+for (name in metrics) {
+  if (metrics.hasOwnProperty(name)) {
+    exports[name] = metrics[name];
+  }
 }
 
-exports.createCollection = function(name) {
+for (name in util) {
+  if (util.hasOwnProperty(name)) {
+    exports[name] = util[name];
+  }
+}
+
+exports.createCollection = function (name) {
   return new Collection(name);
 };
+
+exports.Collection = Collection;

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -1,23 +1,29 @@
+'use strict';
+
 var metrics = require('./metrics');
 
-module.exports = Collection;
 function Collection(name) {
   this.name     = name;
   this._metrics = {};
 }
 
-Collection.prototype.register = function(name, metric) {
+Collection.prototype.register = function (name, metric) {
   this._metrics[name] = metric;
 };
 
-Collection.prototype.toJSON = function() {
+Collection.prototype.toJSON = function () {
   var json = {};
 
-  for (var metric in this._metrics) {
-    json[metric] = this._metrics[metric].toJSON();
+  var metric;
+  for (metric in this._metrics) {
+    if (this._metrics.hasOwnProperty(metric)) {
+      json[metric] = this._metrics[metric].toJSON();
+    }
   }
 
-  if (!this.name) return json;
+  if (!this.name) {
+    return json;
+  }
 
   var wrapper = {};
   wrapper[this.name] = json;
@@ -27,7 +33,7 @@ Collection.prototype.toJSON = function() {
 
 Collection.prototype.end = function end() {
   var metrics = this._metrics;
-  Object.keys(metrics).forEach(function(name) {
+  Object.keys(metrics).forEach(function (name) {
     var metric = metrics[name];
     if (metric.end) {
       metric.end();
@@ -37,17 +43,23 @@ Collection.prototype.end = function end() {
 
 Object
   .keys(metrics)
-  .forEach(function(name) {
+  .forEach(function (name) {
     var MetricConstructor = metrics[name];
     var method = name.substr(0, 1).toLowerCase() + name.substr(1);
 
-    Collection.prototype[method] = function(name, properties) {
-      if (!name) throw new Error('Collection.NoMetricName');
+    Collection.prototype[method] = function (name, properties) {
+      if (!name) {
+        throw new Error('Collection.NoMetricName');
+      }
 
-      if (this._metrics[name]) return this._metrics[name];
+      if (this._metrics[name]) {
+        return this._metrics[name];
+      }
 
       var metric = new MetricConstructor(properties);
       this.register(name, metric);
       return metric;
     };
   });
+
+module.exports = Collection;

--- a/lib/metrics/Counter.js
+++ b/lib/metrics/Counter.js
@@ -1,22 +1,25 @@
-module.exports = Counter;
+'use strict';
+
 function Counter(properties) {
   properties = properties || {};
 
   this._count = properties.count || 0;
 }
 
-Counter.prototype.toJSON = function() {
+Counter.prototype.toJSON = function () {
   return this._count;
 };
 
-Counter.prototype.inc = function(n) {
+Counter.prototype.inc = function (n) {
   this._count += (n || 1);
 };
 
-Counter.prototype.dec = function(n) {
+Counter.prototype.dec = function (n) {
   this._count -= (n || 1);
 };
 
-Counter.prototype.reset = function(count) {
+Counter.prototype.reset = function (count) {
   this._count = count || 0;
 };
+
+module.exports = Counter;

--- a/lib/metrics/Gauge.js
+++ b/lib/metrics/Gauge.js
@@ -1,9 +1,12 @@
-module.exports = Gauge;
+'use strict';
+
 function Gauge(readFn) {
   this._readFn = readFn;
 }
 
 // This is sync for now, but maybe async gauges would be useful as well?
-Gauge.prototype.toJSON = function() {
+Gauge.prototype.toJSON = function () {
   return this._readFn();
 };
+
+module.exports = Gauge;

--- a/lib/metrics/Histogram.js
+++ b/lib/metrics/Histogram.js
@@ -1,6 +1,7 @@
+'use strict';
+
 var EDS = require('../util/ExponentiallyDecayingSample');
 
-module.exports = Histogram;
 function Histogram(properties) {
   properties = properties || {};
 
@@ -16,7 +17,7 @@ function Histogram(properties) {
   this._varianceS = 0;
 }
 
-Histogram.prototype.update = function(value) {
+Histogram.prototype.update = function (value) {
   this._count++;
   this._sum += value;
 
@@ -26,10 +27,10 @@ Histogram.prototype.update = function(value) {
   this._updateVariance(value);
 };
 
-Histogram.prototype.percentiles = function(percentiles) {
+Histogram.prototype.percentiles = function (percentiles) {
   var values = this._sample
     .toArray()
-    .sort(function(a, b) {
+    .sort(function (a, b) {
       return (a === b)
         ? 0
         : a - b;
@@ -37,35 +38,34 @@ Histogram.prototype.percentiles = function(percentiles) {
 
   var results = {};
 
-  for (var i = 0; i < percentiles.length; i++) {
-    var percentile = percentiles[i];
-    if (!values.length) {
-      results[percentile] = null;
-      continue;
-    }
-
-    var pos        = percentile * (values.length + 1);
-
-    if (pos < 1) {
-      results[percentile] = values[0];
-    } else if (pos >= values.length) {
-      results[percentile] = values[values.length - 1];
+  var i, percentile, pos, lower, upper;
+  for (i = 0; i < percentiles.length; i++) {
+    percentile = percentiles[i];
+    if (values.length) {
+      pos = percentile * (values.length + 1);
+      if (pos < 1) {
+        results[percentile] = values[0];
+      } else if (pos >= values.length) {
+        results[percentile] = values[values.length - 1];
+      } else {
+        lower = values[Math.floor(pos) - 1];
+        upper = values[Math.ceil(pos) - 1];
+        results[percentile] =
+          lower + (pos - Math.floor(pos)) * (upper - lower);
+      }
     } else {
-      var lower = values[Math.floor(pos) - 1];
-      var upper = values[Math.ceil(pos) - 1];
-
-      results[percentile] = lower + (pos - Math.floor(pos)) * (upper - lower);
+      results[percentile] = null;
     }
   }
 
   return results;
 };
 
-Histogram.prototype.reset = function() {
-  this.constructor.call(this);
+Histogram.prototype.reset = function () {
+  this.constructor();
 };
 
-Histogram.prototype.toJSON = function() {
+Histogram.prototype.toJSON = function () {
   var percentiles = this.percentiles([0.5, 0.75, 0.95, 0.99, 0.999]);
 
   return {
@@ -84,20 +84,23 @@ Histogram.prototype.toJSON = function() {
   };
 };
 
-Histogram.prototype._updateMin = function(value) {
+Histogram.prototype._updateMin = function (value) {
   if (this._min === null || value < this._min) {
     this._min = value;
   }
 };
 
-Histogram.prototype._updateMax = function(value) {
+Histogram.prototype._updateMax = function (value) {
   if (this._max === null || value > this._max) {
     this._max = value;
   }
 };
 
-Histogram.prototype._updateVariance = function(value) {
-  if (this._count === 1) return this._varianceM = value;
+Histogram.prototype._updateVariance = function (value) {
+  if (this._count === 1) {
+    this._varianceM = value;
+    return value;
+  }
 
   var oldM = this._varianceM;
 
@@ -105,20 +108,22 @@ Histogram.prototype._updateVariance = function(value) {
   this._varianceS += ((value - oldM) * (value - this._varianceM));
 };
 
-Histogram.prototype._calculateMean = function() {
+Histogram.prototype._calculateMean = function () {
   return (this._count === 0)
     ? 0
     : this._sum / this._count;
 };
 
-Histogram.prototype._calculateVariance = function() {
+Histogram.prototype._calculateVariance = function () {
   return (this._count <= 1)
     ? null
     : this._varianceS / (this._count - 1);
 };
 
-Histogram.prototype._calculateStddev = function() {
+Histogram.prototype._calculateStddev = function () {
   return (this._count < 1)
     ? null
     : Math.sqrt(this._calculateVariance());
 };
+
+module.exports = Histogram;

--- a/lib/metrics/Meter.js
+++ b/lib/metrics/Meter.js
@@ -1,16 +1,19 @@
-var units = require('../util/units');
-var EWMA  = require('../util/ExponentiallyMovingWeightedAverage');
+'use strict';
+
+var units     = require('../util/units');
+var EWMA      = require('../util/ExponentiallyMovingWeightedAverage');
 var Stopwatch = require('../util/Stopwatch');
 
-module.exports = Meter;
 function Meter(properties) {
   properties = properties || {};
 
   this._rateUnit     = properties.rateUnit || Meter.RATE_UNIT;
   this._tickInterval = properties.tickInterval || Meter.TICK_INTERVAL;
-  if (properties.getTime) this._getTime = properties.getTime;
+  if (properties.getTime) {
+    this._getTime = properties.getTime;
+  }
 
-  this._m1Rate     = new EWMA(1 * units.MINUTES, this._tickInterval);
+  this._m1Rate     = new EWMA(units.MINUTES, this._tickInterval);
   this._m5Rate     = new EWMA(5 * units.MINUTES, this._tickInterval);
   this._m15Rate    = new EWMA(15 * units.MINUTES, this._tickInterval);
   this._count      = 0;
@@ -23,8 +26,10 @@ function Meter(properties) {
 Meter.RATE_UNIT     = units.SECONDS;
 Meter.TICK_INTERVAL = 5 * units.SECONDS;
 
-Meter.prototype.mark = function(n) {
-  if (!this._interval) this.start();
+Meter.prototype.mark = function (n) {
+  if (!this._interval) {
+    this.start();
+  }
 
   n = n || 1;
 
@@ -35,45 +40,48 @@ Meter.prototype.mark = function(n) {
   this._m15Rate.update(n);
 };
 
-Meter.prototype.start = function() {
+Meter.prototype.start = function () {
+  return;
 };
 
-Meter.prototype.end = function() {
+Meter.prototype.end = function () {
   clearInterval(this._interval);
   this._interval = null;
 };
 
-Meter.prototype.ref = function() {
+Meter.prototype.ref = function () {
   if (this._interval && this._interval.ref) {
     this._interval.ref();
   }
 };
 
-Meter.prototype.unref = function() {
+Meter.prototype.unref = function () {
   if (this._interval && this._interval.unref) {
     this._interval.unref();
   }
 };
 
-Meter.prototype._tick = function() {
+Meter.prototype._tick = function () {
   this._m1Rate.tick();
   this._m5Rate.tick();
   this._m15Rate.tick();
 };
 
-Meter.prototype.reset = function() {
+Meter.prototype.reset = function () {
   this.end();
-  this.constructor.call(this);
+  this.constructor();
 };
 
-Meter.prototype.meanRate = function() {
-  if (this._count === 0) return 0;
+Meter.prototype.meanRate = function () {
+  if (this._count === 0) {
+    return 0;
+  }
 
   var elapsed = this._getTime() - this._startTime;
   return this._count / elapsed * this._rateUnit;
 };
 
-Meter.prototype.currentRate = function() {
+Meter.prototype.currentRate = function () {
   var currentSum  = this._currentSum;
   var duration    = this._getTime() - this._lastToJSON;
   var currentRate = currentSum / duration * this._rateUnit;
@@ -85,7 +93,7 @@ Meter.prototype.currentRate = function() {
   return currentRate || 0;
 };
 
-Meter.prototype.toJSON = function() {
+Meter.prototype.toJSON = function () {
   return {
     'mean'         : this.meanRate(),
     'count'        : this._count,
@@ -96,9 +104,13 @@ Meter.prototype.toJSON = function() {
   };
 };
 
-Meter.prototype._getTime = function() {
-  if (!process.hrtime) return Date.now();
+Meter.prototype._getTime = function () {
+  if (!process.hrtime) {
+    return new Date().getTime();
+  }
 
   var hrtime = process.hrtime();
   return hrtime[0] * 1000 + hrtime[1] / (1000 * 1000);
 };
+
+module.exports = Meter;

--- a/lib/metrics/Timer.js
+++ b/lib/metrics/Timer.js
@@ -1,62 +1,68 @@
+'use strict';
+
 var Histogram = require('./Histogram');
 var Meter     = require('./Meter');
 var Stopwatch = require('../util/Stopwatch');
 
-module.exports = Timer;
 function Timer(properties) {
   properties = properties || {};
 
-  this._meter     = properties.meter || new Meter;
-  this._histogram = properties.histogram || new Histogram;
-  this._getTime = properties.getTime;
+  this._meter     = properties.meter || new Meter();
+  this._histogram = properties.histogram || new Histogram();
+  this._getTime   = properties.getTime;
 }
 
-Timer.prototype.start = function() {
+Timer.prototype.start = function () {
   var self  = this;
   var watch = new Stopwatch({getTime: this._getTime});
 
-  watch.once('end', function(elapsed) {
+  watch.once('end', function (elapsed) {
     self.update(elapsed);
   });
 
   return watch;
 };
 
-Timer.prototype.update = function(value) {
+Timer.prototype.update = function (value) {
   this._meter.mark();
   this._histogram.update(value);
 };
 
 
-Timer.prototype.reset = function() {
+Timer.prototype.reset = function () {
   this._meter.reset();
   this._histogram.reset();
 };
 
-Timer.prototype.end = function() {
+Timer.prototype.end = function () {
   this._meter.end();
 };
 
-Timer.prototype.ref = function() {
+Timer.prototype.ref = function () {
   this._meter.ref();
 };
 
-Timer.prototype.unref = function() {
+Timer.prototype.unref = function () {
   this._meter.unref();
 };
 
-Timer.prototype.toJSON = function() {
+Timer.prototype.toJSON = function () {
   var self   = this;
   var result = {};
 
-  ['meter', 'histogram'].forEach(function(metric) {
+  ['meter', 'histogram'].forEach(function (metric) {
     var json       = self['_' + metric].toJSON();
     result[metric] = {};
 
-    for (var key in json) {
-      result[metric][key] = json[key];
+    var key;
+    for (key in json) {
+      if (json.hasOwnProperty(key)) {
+        result[metric][key] = json[key];
+      }
     }
   });
 
   return result;
 };
+
+module.exports = Timer;

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -1,8 +1,7 @@
-require('fs')
-  .readdirSync(__dirname)
-  .forEach(function(name) {
-    var match = name.match(/(.+)\.js$/);
-    if (!match || name === 'index.js') return;
+'use strict';
 
-    exports[match[1]] = require('./' + match[1]);
-  });
+exports.Counter   = require('./Counter');
+exports.Gauge     = require('./Gauge');
+exports.Histogram = require('./Histogram');
+exports.Meter     = require('./Meter');
+exports.Timer     = require('./Timer');

--- a/lib/util/BinaryHeap.js
+++ b/lib/util/BinaryHeap.js
@@ -1,6 +1,7 @@
+'use strict';
+
 // Based on http://en.wikipedia.org/wiki/Binary_Heap
 // as well as http://eloquentjavascript.net/appendix2.html
-module.exports = BinaryHeap;
 function BinaryHeap(options) {
   options = options || {};
 
@@ -8,20 +9,21 @@ function BinaryHeap(options) {
   this._score    = options.score || this._score;
 }
 
-BinaryHeap.prototype.add = function(/* elements */) {
-  for (var i = 0; i < arguments.length; i++) {
-    var element = arguments[i];
+BinaryHeap.prototype.add = function () {
+  var i, element;
+  for (i = 0; i < arguments.length; i++) {
+    element = arguments[i];
 
     this._elements.push(element);
     this._bubble(this._elements.length - 1);
   }
 };
 
-BinaryHeap.prototype.first = function() {
+BinaryHeap.prototype.first = function () {
   return this._elements[0];
 };
 
-BinaryHeap.prototype.removeFirst = function() {
+BinaryHeap.prototype.removeFirst = function () {
   var root = this._elements[0];
   var last = this._elements.pop();
 
@@ -33,20 +35,23 @@ BinaryHeap.prototype.removeFirst = function() {
   return root;
 };
 
-BinaryHeap.prototype.clone = function() {
+BinaryHeap.prototype.clone = function () {
   return new BinaryHeap({
     elements: this.toArray(),
     score: this._score,
   });
 };
 
-BinaryHeap.prototype.toSortedArray = function() {
+BinaryHeap.prototype.toSortedArray = function () {
   var array = [];
   var clone = this.clone();
+  var element;
 
   while (true) {
-    var element = clone.removeFirst();
-    if (element === undefined) break;
+    element = clone.removeFirst();
+    if (element === undefined) {
+      break;
+    }
 
     array.push(element);
   }
@@ -54,49 +59,64 @@ BinaryHeap.prototype.toSortedArray = function() {
   return array;
 };
 
-BinaryHeap.prototype.toArray = function() {
+BinaryHeap.prototype.toArray = function () {
   return [].concat(this._elements);
 };
 
-BinaryHeap.prototype.size = function() {
+BinaryHeap.prototype.size = function () {
   return this._elements.length;
 };
 
-BinaryHeap.prototype._bubble = function(bubbleIndex) {
+BinaryHeap.prototype._bubble = function (bubbleIndex) {
   var bubbleElement = this._elements[bubbleIndex];
   var bubbleScore   = this._score(bubbleElement);
+  var parentIndex;
+  var parentElement;
+  var parentScore;
 
   while (bubbleIndex > 0) {
-    var parentIndex   = this._parentIndex(bubbleIndex);
-    var parentElement = this._elements[parentIndex];
-    var parentScore   = this._score(parentElement);
+    parentIndex   = this._parentIndex(bubbleIndex);
+    parentElement = this._elements[parentIndex];
+    parentScore   = this._score(parentElement);
 
-    if (bubbleScore <= parentScore) break;
+    if (bubbleScore <= parentScore) {
+      break;
+    }
 
     this._elements[parentIndex] = bubbleElement;
-    this._elements[bubbleIndex]  = parentElement;
-    bubbleIndex                  = parentIndex;
+    this._elements[bubbleIndex] = parentElement;
+    bubbleIndex                 = parentIndex;
   }
 };
 
-BinaryHeap.prototype._sink = function(sinkIndex) {
+BinaryHeap.prototype._sink = function (sinkIndex) {
   var sinkElement = this._elements[sinkIndex];
   var sinkScore   = this._score(sinkElement);
   var length      = this._elements.length;
+  var swapIndex;
+  var swapScore;
+  var swapElement;
+  var childIndexes;
+  var i;
+  var childIndex;
+  var childElement;
+  var childScore;
 
   while (true) {
-    var swapIndex    = null;
-    var swapScore    = null;
-    var swapElement  = null;
-    var childIndexes = this._childIndexes(sinkIndex);
+    swapIndex    = null;
+    swapScore    = null;
+    swapElement  = null;
+    childIndexes = this._childIndexes(sinkIndex);
 
-    for (var i = 0; i < childIndexes.length; i++) {
-      var childIndex   = childIndexes[i];
+    for (i = 0; i < childIndexes.length; i++) {
+      childIndex = childIndexes[i];
 
-      if (childIndex >= length) break;
+      if (childIndex >= length) {
+        break;
+      }
 
-      var childElement = this._elements[childIndex];
-      var childScore   = this._score(childElement);
+      childElement = this._elements[childIndex];
+      childScore   = this._score(childElement);
 
       if (childScore > sinkScore) {
         if (swapScore === null || swapScore < childScore) {
@@ -107,7 +127,9 @@ BinaryHeap.prototype._sink = function(sinkIndex) {
       }
     }
 
-    if (swapIndex === null) break;
+    if (swapIndex === null) {
+      break;
+    }
 
     this._elements[swapIndex] = sinkElement;
     this._elements[sinkIndex] = swapElement;
@@ -115,18 +137,19 @@ BinaryHeap.prototype._sink = function(sinkIndex) {
   }
 };
 
-BinaryHeap.prototype._parentIndex = function(index) {
+BinaryHeap.prototype._parentIndex = function (index) {
   return Math.floor((index - 1) / 2);
 };
 
-BinaryHeap.prototype._childIndexes = function(index) {
+BinaryHeap.prototype._childIndexes = function (index) {
   return [
     2 * index + 1,
     2 * index + 2,
   ];
-  return ;
 };
 
-BinaryHeap.prototype._score = function(element) {
+BinaryHeap.prototype._score = function (element) {
   return element.valueOf();
 };
+
+module.exports = BinaryHeap;

--- a/lib/util/ExponentiallyDecayingSample.js
+++ b/lib/util/ExponentiallyDecayingSample.js
@@ -1,17 +1,19 @@
+'use strict';
+
 var BinaryHeap = require('./BinaryHeap');
 var units      = require('./units');
 
-module.exports = ExponentiallyDecayingSample;
 function ExponentiallyDecayingSample(options) {
   options = options || {};
 
   this._elements = new BinaryHeap({
-    score: function(element) {
+    score: function (element) {
       return -element.priority;
     }
   });
 
-  this._rescaleInterval = options.rescaleInterval || ExponentiallyDecayingSample.RESCALE_INTERVAL;
+  this._rescaleInterval = options.rescaleInterval
+    || ExponentiallyDecayingSample.RESCALE_INTERVAL;
   this._alpha           = options.alpha || ExponentiallyDecayingSample.ALPHA;
   this._size            = options.size || ExponentiallyDecayingSample.SIZE;
   this._random          = options.random || this._random;
@@ -19,11 +21,11 @@ function ExponentiallyDecayingSample(options) {
   this._nextRescale     = null;
 }
 
-ExponentiallyDecayingSample.RESCALE_INTERVAL = 1 * units.HOURS;
+ExponentiallyDecayingSample.RESCALE_INTERVAL = units.HOURS;
 ExponentiallyDecayingSample.ALPHA            = 0.015;
 ExponentiallyDecayingSample.SIZE             = 1028;
 
-ExponentiallyDecayingSample.prototype.update = function(value, timestamp) {
+ExponentiallyDecayingSample.prototype.update = function (value, timestamp) {
   var now = Date.now();
   if (!this._landmark) {
     this._landmark    = now;
@@ -46,41 +48,43 @@ ExponentiallyDecayingSample.prototype.update = function(value, timestamp) {
     this._elements.add(element);
   }
 
-  if (now >= this._nextRescale) this._rescale(now);
+  if (now >= this._nextRescale) {
+    this._rescale(now);
+  }
 };
 
-ExponentiallyDecayingSample.prototype.toSortedArray = function() {
+ExponentiallyDecayingSample.prototype.toSortedArray = function () {
   return this._elements
     .toSortedArray()
-    .map(function(element) {
+    .map(function (element) {
       return element.value;
     });
 };
 
 
-ExponentiallyDecayingSample.prototype.toArray = function() {
+ExponentiallyDecayingSample.prototype.toArray = function () {
   return this._elements
     .toArray()
-    .map(function(element) {
+    .map(function (element) {
       return element.value;
     });
 };
 
-ExponentiallyDecayingSample.prototype._weight = function(age) {
+ExponentiallyDecayingSample.prototype._weight = function (age) {
   // We divide by 1000 to not run into huge numbers before reaching a
   // rescale event.
   return Math.exp(this._alpha * (age / 1000));
 };
 
-ExponentiallyDecayingSample.prototype._priority = function(age) {
+ExponentiallyDecayingSample.prototype._priority = function (age) {
   return this._weight(age) / this._random();
 };
 
-ExponentiallyDecayingSample.prototype._random = function() {
+ExponentiallyDecayingSample.prototype._random = function () {
   return Math.random();
 };
 
-ExponentiallyDecayingSample.prototype._rescale = function(now) {
+ExponentiallyDecayingSample.prototype._rescale = function (now) {
   now               = now || Date.now();
 
   var self          = this;
@@ -92,7 +96,9 @@ ExponentiallyDecayingSample.prototype._rescale = function(now) {
 
   this._elements
     .toArray()
-    .forEach(function(element) {
+    .forEach(function (element) {
       element.priority *= factor;
     });
 };
+
+module.exports = ExponentiallyDecayingSample;

--- a/lib/util/ExponentiallyMovingWeightedAverage.js
+++ b/lib/util/ExponentiallyMovingWeightedAverage.js
@@ -1,26 +1,30 @@
+'use strict';
+
 var units = require('./units');
 
-module.exports = ExponentiallyMovingWeightedAverage;
 function ExponentiallyMovingWeightedAverage(timePeriod, tickInterval) {
-  this._timePeriod   = timePeriod || 1 * units.MINUTE;
-  this._tickInterval = tickInterval || ExponentiallyMovingWeightedAverage.TICK_INTERVAL;
+  this._timePeriod   = timePeriod || units.MINUTE;
+  this._tickInterval = tickInterval
+    || ExponentiallyMovingWeightedAverage.TICK_INTERVAL;
   this._alpha        = 1 - Math.exp(-this._tickInterval / this._timePeriod);
   this._count        = 0;
   this._rate         = 0;
 }
 ExponentiallyMovingWeightedAverage.TICK_INTERVAL = 5 * units.SECONDS;
 
-ExponentiallyMovingWeightedAverage.prototype.update = function(n) {
+ExponentiallyMovingWeightedAverage.prototype.update = function (n) {
   this._count += n;
 };
 
-ExponentiallyMovingWeightedAverage.prototype.tick = function() {
+ExponentiallyMovingWeightedAverage.prototype.tick = function () {
   var instantRate = this._count / this._tickInterval;
   this._count     = 0;
 
   this._rate += (this._alpha * (instantRate - this._rate));
 };
 
-ExponentiallyMovingWeightedAverage.prototype.rate = function(timeUnit) {
+ExponentiallyMovingWeightedAverage.prototype.rate = function (timeUnit) {
   return (this._rate || 0) * timeUnit;
 };
+
+module.exports = ExponentiallyMovingWeightedAverage;

--- a/lib/util/Stopwatch.js
+++ b/lib/util/Stopwatch.js
@@ -1,19 +1,25 @@
-var util         = require('util');
+'use strict';
+
+var inherits     = require('inherits');
 var EventEmitter = require('events').EventEmitter;
 
-module.exports = Stopwatch;
-util.inherits(Stopwatch, EventEmitter);
 function Stopwatch(options) {
   options = options || {};
   EventEmitter.call(this);
 
-  if (options.getTime) this._getTime = options.getTime;
+  if (options.getTime) {
+    this._getTime = options.getTime;
+  }
   this._start = this._getTime();
   this._ended = false;
 }
 
-Stopwatch.prototype.end = function() {
-  if (this._ended) return;
+inherits(Stopwatch, EventEmitter);
+
+Stopwatch.prototype.end = function () {
+  if (this._ended) {
+    return;
+  }
 
   this._ended = true;
   var elapsed   = this._getTime() - this._start;
@@ -22,9 +28,13 @@ Stopwatch.prototype.end = function() {
   return elapsed;
 };
 
-Stopwatch.prototype._getTime = function() {
-  if (!process.hrtime) return Date.now();
+Stopwatch.prototype._getTime = function () {
+  if (!process.hrtime) {
+    return Date.now();
+  }
 
   var hrtime = process.hrtime();
   return hrtime[0] * 1000 + hrtime[1] / (1000 * 1000);
 };
+
+module.exports = Stopwatch;

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -1,8 +1,9 @@
-require('fs')
-  .readdirSync(__dirname)
-  .forEach(function(name) {
-    var match = name.match(/(.+)\.js$/);
-    if (!match || name === 'index.js') return;
+'use strict';
 
-    exports[match[1]] = require('./' + match[1]);
-  });
+exports.units      = require('./units');
+exports.BinaryHeap = require('./BinaryHeap');
+exports.Stopwatch  = require('./Stopwatch');
+exports.ExponentiallyDecayingSample
+  = require('./ExponentiallyDecayingSample');
+exports.ExponentiallyMovingWeightedAverage
+  = require('./ExponentiallyMovingWeightedAverage');

--- a/lib/util/units.js
+++ b/lib/util/units.js
@@ -1,5 +1,7 @@
+'use strict';
 // Time units, as found in Java:
-// see: http://download.oracle.com/javase/6/docs/api/java/util/concurrent/TimeUnit.html
+// http://download.oracle.com/
+//   javase/6/docs/api/java/util/concurrent/TimeUnit.html
 exports.NANOSECONDS  = 1 / (1000 * 1000);
 exports.MICROSECONDS = 1 / 1000;
 exports.MILLISECONDS = 1;

--- a/package.json
+++ b/package.json
@@ -4,21 +4,26 @@
   "description": "This is an alternative port of Coda Hale's metrics library.",
   "version": "0.1.5",
   "homepage": "https://github.com/felixge/node-measured",
-  "repository": {
-    "url": "git://github.com/felixge/node-measured.git"
+  "engines": {
+    "node": ">= 0.10"
   },
   "main": "./index",
   "scripts": {
-    "test": "make test"
+    "lint": "jslint --color './**/*.js'",
+    "test-node": "mocha './test/**/test-*.js'",
+    "test-browser": "mochify './test/**/test-*.js'",
+    "test": "npm run lint && npm run test-node && npm run test-browser"
   },
-  "engines": {
-    "node": "*"
+  "dependencies": {
+    "inherits": "^2.0"
   },
-  "dependencies": {},
   "devDependencies": {
-    "urun": "0.0.4",
-    "utest": "0.0.3",
-    "sinon": "git://github.com/felixge/Sinon.JS.git#stub-prototype-properties"
+    "jslint": "^0.7",
+    "mocha": "^2.1",
+    "mochify": "^2.1",
+    "sinon": "^1.12"
   },
-  "optionalDependencies": {}
+  "repository": {
+    "url": "git://github.com/felixge/node-measured.git"
+  }
 }

--- a/test/common.js
+++ b/test/common.js
@@ -1,3 +1,6 @@
+'use strict';
+
+/*
 var common = exports;
 var path   = require('path');
 
@@ -6,3 +9,5 @@ common.dir.root = path.dirname(__dirname);
 common.dir.lib  = path.join(common.dir.root, 'lib');
 
 common.measured = require(common.dir.root);
+*/
+exports.measured = require('../index');

--- a/test/integration/test-Collection_end.js
+++ b/test/integration/test-Collection_end.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var common = require('../common');
 
 var collection = new common.measured.Collection();

--- a/test/run.js
+++ b/test/run.js
@@ -1,1 +1,0 @@
-require('urun')(__dirname);

--- a/test/unit/metrics/test-Counter.js
+++ b/test/unit/metrics/test-Counter.js
@@ -1,57 +1,59 @@
+/*global describe, it, beforeEach, afterEach*/
+'use strict';
+
 var common  = require('../../common');
-var test    = require('utest');
 var assert  = require('assert');
 var Counter = common.measured.Counter;
 
-var counter;
-test('Counter', {
-  before: function() {
+describe('Counter', function () {
+  var counter;
+  beforeEach(function () {
     counter = new Counter();
-  },
+  });
 
-  'has initial value of 0': function() {
+  it('has initial value of 0', function () {
     var json = counter.toJSON();
     assert.deepEqual(json, 0);
-  },
+  });
 
-  'can be initialized with a given count': function() {
-    var counter = new Counter({count: 5});
+  it('can be initialized with a given count', function () {
+    counter = new Counter({count: 5});
     assert.equal(counter.toJSON(), 5);
-  },
+  });
 
-  '#inc works incrementally': function() {
+  it('#inc works incrementally', function () {
     counter.inc(5);
     assert.equal(counter.toJSON(), 5);
 
     counter.inc(3);
     assert.equal(counter.toJSON(), 8);
-  },
+  });
 
-  '#inc defaults to 1': function() {
+  it('#inc defaults to 1', function () {
     counter.inc();
     assert.equal(counter.toJSON(), 1);
 
     counter.inc();
     assert.equal(counter.toJSON(), 2);
-  },
+  });
 
-  '#dec works incrementally': function() {
+  it('#dec works incrementally', function () {
     counter.dec(3);
     assert.equal(counter.toJSON(), -3);
 
     counter.dec(2);
     assert.equal(counter.toJSON(), -5);
-  },
+  });
 
-  '#dec defaults to 1': function() {
+  it('#dec defaults to 1', function () {
     counter.dec();
     assert.equal(counter.toJSON(), -1);
 
     counter.dec();
     assert.equal(counter.toJSON(), -2);
-  },
+  });
 
-  '#reset works': function() {
+  it('#reset works', function () {
     counter.inc(23);
     assert.equal(counter.toJSON(), 23);
 
@@ -60,5 +62,5 @@ test('Counter', {
 
     counter.reset(50);
     assert.equal(counter.toJSON(), 50);
-  }
+  });
 });

--- a/test/unit/metrics/test-Gauge.js
+++ b/test/unit/metrics/test-Gauge.js
@@ -1,16 +1,18 @@
+/*global describe, it, beforeEach, afterEach*/
+'use strict';
+
 var common = require('../../common');
-var test   = require('utest');
 var assert = require('assert');
 
-test('Gauge', {
-  'reads value from function': function() {
+describe('Gauge', function () {
+  it('reads value from function', function () {
     var i = 0;
 
-    var gauge = new common.measured.Gauge(function() {
+    var gauge = new common.measured.Gauge(function () {
       return i++;
     });
 
     assert.equal(gauge.toJSON(), 0);
     assert.equal(gauge.toJSON(), 1);
-  },
+  });
 });

--- a/test/unit/metrics/test-Histogram.js
+++ b/test/unit/metrics/test-Histogram.js
@@ -1,178 +1,195 @@
+/*global describe, it, beforeEach, afterEach*/
+'use strict';
+
 var common    = require('../../common');
-var test      = require('utest');
 var assert    = require('assert');
 var sinon     = require('sinon');
 var Histogram = common.measured.Histogram;
 var EDS       = common.measured.ExponentiallyDecayingSample;
 
-var histogram;
-test('Histogram', {
-  before: function() {
-    histogram = new Histogram;
-  },
+describe('Histogram', function () {
+  var histogram;
+  beforeEach(function () {
+    histogram = new Histogram();
+  });
 
-  'all values are null in the beginning': function() {
+  it('all values are null in the beginning', function () {
     var json = histogram.toJSON();
-    assert.strictEqual(json['min'], null);
-    assert.strictEqual(json['max'], null);
-    assert.strictEqual(json['sum'], 0);
-    assert.strictEqual(json['variance'], null);
-    assert.strictEqual(json['mean'], 0);
-    assert.strictEqual(json['stddev'], null);
-    assert.strictEqual(json['count'], 0);
-    assert.strictEqual(json['median'], null);
-    assert.strictEqual(json['p75'], null);
-    assert.strictEqual(json['p95'], null);
-    assert.strictEqual(json['p99'], null);
-    assert.strictEqual(json['p999'], null);
-  },
+    assert.strictEqual(json.min, null);
+    assert.strictEqual(json.max, null);
+    assert.strictEqual(json.sum, 0);
+    assert.strictEqual(json.variance, null);
+    assert.strictEqual(json.mean, 0);
+    assert.strictEqual(json.stddev, null);
+    assert.strictEqual(json.count, 0);
+    assert.strictEqual(json.median, null);
+    assert.strictEqual(json.p75, null);
+    assert.strictEqual(json.p95, null);
+    assert.strictEqual(json.p99, null);
+    assert.strictEqual(json.p999, null);
+  });
 });
 
-var sample;
-test('Histogram#update', {
-  before: function() {
-    sample    = sinon.stub(new EDS);
+describe('Histogram#update', function () {
+  var sample;
+  var histogram;
+  beforeEach(function () {
+    sample    = sinon.stub(new EDS());
     histogram = new Histogram({sample: sample});
 
     sample.toArray.returns([]);
-  },
+  });
 
-  'updates underlaying sample': function() {
+  it('updates underlaying sample', function () {
     histogram.update(5);
     assert.ok(sample.update.calledWith(5));
-  },
+  });
 
-  'keeps track of min': function() {
+  it('keeps track of min', function () {
     histogram.update(5);
     histogram.update(3);
     histogram.update(6);
 
     assert.equal(histogram.toJSON().min, 3);
-  },
+  });
 
-  'keeps track of max': function() {
+  it('keeps track of max', function () {
     histogram.update(5);
     histogram.update(9);
     histogram.update(3);
 
     assert.equal(histogram.toJSON().max, 9);
-  },
+  });
 
-  'keeps track of sum': function() {
+  it('keeps track of sum', function () {
     histogram.update(5);
     histogram.update(1);
     histogram.update(12);
 
     assert.equal(histogram.toJSON().sum, 18);
-  },
+  });
 
-  'keeps track of count': function() {
+  it('keeps track of count', function () {
     histogram.update(5);
     histogram.update(1);
     histogram.update(12);
 
     assert.equal(histogram.toJSON().count, 3);
-  },
+  });
 
-  'keeps track of mean': function() {
+  it('keeps track of mean', function () {
     histogram.update(5);
     histogram.update(1);
     histogram.update(12);
 
     assert.equal(histogram.toJSON().mean, 6);
-  },
+  });
 
-  'keeps track of variance (example without variance)': function() {
+  it('keeps track of variance (example without variance)', function () {
     histogram.update(5);
     histogram.update(5);
     histogram.update(5);
 
     assert.equal(histogram.toJSON().variance, 0);
-  },
+  });
 
-  'keeps track of variance (example with variance)': function() {
+  it('keeps track of variance (example with variance)', function () {
     histogram.update(1);
     histogram.update(2);
     histogram.update(3);
     histogram.update(4);
 
     assert.equal(histogram.toJSON().variance.toFixed(3), '1.667');
-  },
+  });
 
-  'keeps track of stddev': function() {
+  it('keeps track of stddev', function () {
     histogram.update(1);
     histogram.update(2);
     histogram.update(3);
     histogram.update(4);
 
     assert.equal(histogram.toJSON().stddev.toFixed(3), '1.291');
-  },
+  });
 
-  'keeps track of percentiles': function() {
+  it('keeps track of percentiles', function () {
     var values = [];
-    for (var i = 1; i <= 100; i++) values.push(i);
+    var i;
+    for (i = 1; i <= 100; i++) {
+      values.push(i);
+    }
     sample.toArray.returns(values);
 
     var json = histogram.toJSON();
-    assert.equal(json['median'].toFixed(3), '50.500');
-    assert.equal(json['p75'].toFixed(3), '75.750');
-    assert.equal(json['p95'].toFixed(3), '95.950');
-    assert.equal(json['p99'].toFixed(3), '99.990');
-    assert.equal(json['p999'].toFixed(3), '100.000');
-  },
+    assert.equal(json.median.toFixed(3), '50.500');
+    assert.equal(json.p75.toFixed(3), '75.750');
+    assert.equal(json.p95.toFixed(3), '95.950');
+    assert.equal(json.p99.toFixed(3), '99.990');
+    assert.equal(json.p999.toFixed(3), '100.000');
+  });
 });
 
-test('Histogram#percentiles', {
-  before: function() {
-    sample    = sinon.stub(new EDS);
+describe('Histogram#percentiles', function () {
+  var sample;
+  var histogram;
+  beforeEach(function () {
+    sample    = sinon.stub(new EDS());
     histogram = new Histogram({sample: sample});
 
     var values = [];
-    for (var i = 1; i <= 100; i++) {
+    var i;
+    for (i = 1; i <= 100; i++) {
       values.push(i);
     }
 
-    for (var i = 0; i < 100; i++) {
-      var swapWith = Math.floor(Math.random() * 100);
-      var value = values[i];
+    var swapWith;
+    var value;
+    for (i = 0; i < 100; i++) {
+      swapWith = Math.floor(Math.random() * 100);
+      value = values[i];
 
       values[i] = values[swapWith];
       values[swapWith] = value;
     }
 
     sample.toArray.returns(values);
-  },
+  });
 
-  'calculates single percentile correctly': function() {
+  it('calculates single percentile correctly', function () {
     var percentiles = histogram.percentiles([0.5]);
     assert.equal(percentiles[0.5], 50.5);
 
-    var percentiles = histogram.percentiles([0.99]);
+    percentiles = histogram.percentiles([0.99]);
     assert.equal(percentiles[0.99], 99.99);
-  },
+  });
 });
 
-test('Histogram#reset', {
-  before: function() {
+describe('Histogram#reset', function () {
+  var sample;
+  var histogram;
+  beforeEach(function () {
+    sample    = new EDS();
     histogram = new Histogram({sample: sample});
-  },
+  });
 
-  'resets all values': function() {
+  it('resets all values', function () {
     histogram.update(5);
     histogram.update(2);
     var json = histogram.toJSON();
 
-    for (var key in json) {
-      var value = json[key];
-      assert.ok(typeof value === 'number');
+    var key;
+    for (key in json) {
+      if (json.hasOwnProperty(key)) {
+        assert.ok(typeof json[key] === 'number');
+      }
     }
 
     histogram.reset();
-    var json = histogram.toJSON();
+    json = histogram.toJSON();
 
-    for (var key in json) {
-      var value = json[key];
-      assert.ok(value === 0 || value === null);
+    for (key in json) {
+      if (json.hasOwnProperty(key)) {
+        assert.ok(json[key] === 0 || json[key] === null);
+      }
     }
-  },
+  });
 });

--- a/test/unit/metrics/test-Timer.js
+++ b/test/unit/metrics/test-Timer.js
@@ -1,63 +1,67 @@
+/*global describe, it, beforeEach, afterEach*/
+'use strict';
+
 var common    = require('../../common');
-var test      = require('utest');
 var assert    = require('assert');
 var sinon     = require('sinon');
 var Timer     = common.measured.Timer;
 var Histogram = common.measured.Histogram;
 var Meter     = common.measured.Meter;
 
-var timer;
-var meter;
-var histogram;
-var clock;
-test('Timer', {
-  before: function() {
-    clock = sinon.useFakeTimers();
-    meter     = sinon.stub(new Meter);
-    histogram = sinon.stub(new Histogram);
+describe('Timer', function () {
+  var timer;
+  var meter;
+  var histogram;
+  var clock;
+  beforeEach(function () {
+    clock     = sinon.useFakeTimers();
+    meter     = sinon.stub(new Meter());
+    histogram = sinon.stub(new Histogram());
 
     timer = new Timer({
       meter     : meter,
       histogram : histogram,
-      getTime: Date.now
+      getTime   : function () {
+        return new Date().getTime();
+      }
     });
-  },
+  });
 
-  after: function() {
+  afterEach(function () {
     clock.restore();
-  },
+  });
 
-  'can be initialized without options': function() {
+  it('can be initialized without options', function () {
     timer = new Timer();
-  },
+  });
 
-  '#update() marks the meter': function() {
+  it('#update() marks the meter', function () {
     timer.update(5);
 
     assert.ok(meter.mark.calledOnce);
-  },
+  });
 
-  '#update() updates the histogram': function() {
+  it('#update() updates the histogram', function () {
     timer.update(5);
 
     assert.ok(histogram.update.calledWith(5));
-  },
+  });
 
-  '#toJSON() contains meter info': function() {
+  it('#toJSON() contains meter info', function () {
     meter.toJSON.returns({a: 1, b: 2});
     var json = timer.toJSON();
 
-    assert.deepEqual(json['meter'], {a: 1, b: 2});
-  },
+    assert.deepEqual(json.meter, {a: 1, b: 2});
+  });
 
-  '#toJSON() contains histogram info': function() {
+  it('#toJSON() contains histogram info', function () {
     histogram.toJSON.returns({c: 3, d: 4});
     var json = timer.toJSON();
 
-    assert.deepEqual(json['histogram'], {c: 3, d: 4});
-  },
+    assert.deepEqual(json.histogram, {c: 3, d: 4});
+  });
 
-  '#start returns a Stopwatch which updates the timer': function() {
+  it('#start returns a Stopwatch which updates the timer', function () {
     clock.tick(10);
 
     var watch = timer.start();
@@ -66,12 +70,12 @@ test('Timer', {
 
     assert.ok(meter.mark.calledOnce);
     assert.equal(histogram.update.args[0][0], 50);
-  },
+  });
 
-  '#reset is delegated to histogram and meter': function() {
+  it('#reset is delegated to histogram and meter', function () {
     timer.reset();
 
     assert.ok(meter.reset.calledOnce);
     assert.ok(histogram.reset.calledOnce);
-  },
+  });
 });

--- a/test/unit/test-Collection.js
+++ b/test/unit/test-Collection.js
@@ -1,15 +1,17 @@
+/*global describe, it, beforeEach, afterEach*/
+'use strict';
+
 var common = require('../common');
-var test   = require('utest');
 var assert = require('assert');
 
-var collection;
-test('Collection', {
-  before: function() {
+describe('Collection', function () {
+  var collection;
+  beforeEach(function () {
     collection = common.measured.createCollection();
-  },
+  });
 
-  'with two counters': function() {
-    var collection = new common.measured.Collection('counters');
+  it('with two counters', function () {
+    collection = new common.measured.Collection('counters');
     var a = collection.counter('a');
     var b = collection.counter('b');
 
@@ -22,18 +24,18 @@ test('Collection', {
         'b': 5,
       }
     });
-  },
+  });
 
-  'returns same metric object when given the same name': function() {
+  it('returns same metric object when given the same name', function () {
     var a1 = collection.counter('a');
     var a2 = collection.counter('a');
 
     assert.strictEqual(a1, a2);
-  },
+  });
 
-  'throws exception when creating a metric without name': function() {
-    assert.throws(function() {
+  it('throws exception when creating a metric without name', function () {
+    assert.throws(function () {
       collection.counter();
-    }, /Collection.NoMetricName/);
-  },
+    }, /Collection\.NoMetricName/);
+  });
 });

--- a/test/unit/util/test-BinaryHeap.js
+++ b/test/unit/util/test-BinaryHeap.js
@@ -1,97 +1,99 @@
+/*global describe, it, beforeEach, afterEach*/
+'use strict';
+
 var common     = require('../../common');
-var test       = require('utest');
 var assert     = require('assert');
 var BinaryHeap = common.measured.BinaryHeap;
 
-test('BinaryHeap#toArray', {
-  'is empty in the beginning': function() {
+describe('BinaryHeap#toArray', function () {
+  it('is empty in the beginning', function () {
     var heap = new BinaryHeap();
     assert.deepEqual(heap.toArray(), []);
-  },
+  });
 
-  'does not leak internal references': function() {
+  it('does not leak internal references', function () {
     var heap  = new BinaryHeap();
     var array = heap.toArray();
     array.push(1);
 
     assert.deepEqual(heap.toArray(), []);
-  },
+  });
 });
 
-test('BinaryHeap#toSortedArray', {
-  'is empty in the beginning': function() {
+describe('BinaryHeap#toSortedArray', function () {
+  it('is empty in the beginning', function () {
     var heap = new BinaryHeap();
     assert.deepEqual(heap.toSortedArray(), []);
-  },
+  });
 
-  'does not leak internal references': function() {
+  it('does not leak internal references', function () {
     var heap  = new BinaryHeap();
     var array = heap.toSortedArray();
     array.push(1);
 
     assert.deepEqual(heap.toSortedArray(), []);
-  },
+  });
 
-  'returns a sorted array': function() {
+  it('returns a sorted array', function () {
     var heap  = new BinaryHeap();
     heap.add(1, 2, 3, 4, 5, 6, 7, 8);
 
     assert.deepEqual(heap.toSortedArray(), [8, 7, 6, 5, 4, 3, 2, 1]);
-  },
+  });
 });
 
-var heap;
-test('BinaryHeap#add', {
-  before: function() {
+describe('BinaryHeap#add', function () {
+  var heap;
+  beforeEach(function () {
     heap = new BinaryHeap();
-  },
+  });
 
-  'lets you add one element': function() {
+  it('lets you add one element', function () {
     heap.add(1);
 
     assert.deepEqual(heap.toArray(), [1]);
-  },
+  });
 
-  'lets you add two elements': function() {
+  it('lets you add two elements', function () {
     heap.add(1);
     heap.add(2);
 
     assert.deepEqual(heap.toArray(), [2, 1]);
-  },
+  });
 
-  'lets you add two elements at once': function() {
+  it('lets you add two elements at once', function () {
     heap.add(1, 2);
 
     assert.deepEqual(heap.toArray(), [2, 1]);
-  },
+  });
 
-  'places elements according to their valueOf()': function() {
+  it('places elements according to their valueOf()', function () {
     heap.add(2);
     heap.add(1);
     heap.add(3);
 
     assert.deepEqual(heap.toArray(), [3, 1, 2]);
-  },
+  });
 });
 
-var heap;
-test('BinaryHeap#removeFirst', {
-  before: function() {
+describe('BinaryHeap#removeFirst', function () {
+  var heap;
+  beforeEach(function () {
     heap = new BinaryHeap();
     heap.add(1, 2, 3, 4, 5, 6, 7, 8);
-  },
+  });
 
-  'removeFirst returns the last element': function() {
+  it('removeFirst returns the last element', function () {
     var element = heap.removeFirst();
     assert.equal(element, 8);
-  },
+  });
 
-  'removeFirst removes the last element': function() {
-    var element = heap.removeFirst();
+  it('removeFirst removes the last element', function () {
+    heap.removeFirst();
     assert.equal(heap.toArray().length, 7);
-  },
+  });
 
-  'removeFirst works multiple times': function() {
+  it('removeFirst works multiple times', function () {
     assert.equal(heap.removeFirst(), 8);
     assert.equal(heap.removeFirst(), 7);
     assert.equal(heap.removeFirst(), 6);
@@ -101,38 +103,38 @@ test('BinaryHeap#removeFirst', {
     assert.equal(heap.removeFirst(), 2);
     assert.equal(heap.removeFirst(), 1);
     assert.equal(heap.removeFirst(), undefined);
-  },
+  });
 });
 
-var heap;
-test('BinaryHeap#first', {
-  before: function() {
+describe('BinaryHeap#first', function () {
+  var heap;
+  beforeEach(function () {
     heap = new BinaryHeap();
     heap.add(1, 2, 3);
-  },
+  });
 
-  'returns the first element but does not remove it': function() {
+  it('returns the first element but does not remove it', function () {
     var element = heap.first();
     assert.equal(element, 3);
 
     assert.equal(heap.toArray().length, 3);
-  },
+  });
 });
 
-test('BinaryHeap#size', {
-  'takes custom score function': function() {
+describe('BinaryHeap#size', function () {
+  it('takes custom score function', function () {
     var heap = new BinaryHeap({elements: [1, 2, 3]});
     assert.equal(heap.size(), 3);
-  },
+  });
 });
 
-test('BinaryHeap', {
-  'takes custom score function': function() {
-    var heap = new BinaryHeap({score: function(obj) {
+describe('BinaryHeap', function () {
+  it('takes custom score function', function () {
+    var heap = new BinaryHeap({score: function (obj) {
       return -obj;
     }});
 
     heap.add(8, 7, 6, 5, 4, 3, 2, 1);
     assert.deepEqual(heap.toSortedArray(), [1, 2, 3, 4, 5, 6, 7, 8]);
-  },
+  });
 });

--- a/test/unit/util/test-ExponentiallyDecayingSample.js
+++ b/test/unit/util/test-ExponentiallyDecayingSample.js
@@ -1,110 +1,112 @@
+/*global describe, it, beforeEach, afterEach*/
+'use strict';
+
 var common = require('../../common');
-var test   = require('utest');
 var assert = require('assert');
 var EDS    = common.measured.ExponentiallyDecayingSample;
 var units  = common.measured.units;
 
-var sample;
-test('ExponentiallyDecayingSample#toSortedArray', {
-  before: function() {
+describe('ExponentiallyDecayingSample#toSortedArray', function () {
+  var sample;
+  beforeEach(function () {
     sample = new EDS({
       size: 3,
-      random: function() {
+      random: function () {
         return 1;
       }
     });
-  },
+  });
 
-  'returns an empty array by default': function() {
+  it('returns an empty array by default', function () {
     assert.deepEqual(sample.toSortedArray(), []);
-  },
+  });
 
-  'is always sorted by priority': function() {
+  it('is always sorted by priority', function () {
     sample.update('a', Date.now() + 3000);
     sample.update('b', Date.now() + 2000);
-    sample.update('c', Date.now() + 0);
+    sample.update('c', Date.now());
 
     assert.deepEqual(sample.toSortedArray(), ['c', 'b', 'a']);
-  },
+  });
 });
 
-var sample;
-test('ExponentiallyDecayingSample#toArray', {
-  before: function() {
+describe('ExponentiallyDecayingSample#toArray', function () {
+  var sample;
+  beforeEach(function () {
     sample = new EDS({
       size: 3,
-      random: function() {
+      random: function () {
         return 1;
       }
     });
-  },
+  });
 
-  'returns an empty array by default': function() {
+  it('returns an empty array by default', function () {
     assert.deepEqual(sample.toArray(), []);
-  },
+  });
 
-  'may return an unsorted array': function() {
+  it('may return an unsorted array', function () {
     sample.update('a', Date.now() + 3000);
     sample.update('b', Date.now() + 2000);
-    sample.update('c', Date.now() + 0);
+    sample.update('c', Date.now());
 
     assert.deepEqual(sample.toArray(), ['c', 'a', 'b']);
-  },
+  });
 });
 
-var sample;
-test('ExponentiallyDecayingSample#update', {
-  before: function() {
+describe('ExponentiallyDecayingSample#update', function () {
+  var sample;
+  beforeEach(function () {
     sample = new EDS({
       size: 2,
-      random: function() {
+      random: function () {
         return 1;
       }
     });
-  },
+  });
 
-  'can add one item': function() {
+  it('can add one item', function () {
     sample.update('a');
 
     assert.deepEqual(sample.toSortedArray(), ['a']);
-  },
+  });
 
-  'sorts items according to priority ascending': function() {
-    sample.update('a', Date.now() + 0);
+  it('sorts items according to priority ascending', function () {
+    sample.update('a', Date.now());
     sample.update('b', Date.now() + 1000);
 
     assert.deepEqual(sample.toSortedArray(), ['a', 'b']);
-  },
+  });
 
-  'pops items with lowest priority': function() {
-    sample.update('a', Date.now() + 0);
+  it('pops items with lowest priority', function () {
+    sample.update('a', Date.now());
     sample.update('b', Date.now() + 1000);
     sample.update('c', Date.now() + 2000);
 
     assert.deepEqual(sample.toSortedArray(), ['b', 'c']);
-  },
+  });
 
-  'items with too low of a priority do not make it in': function() {
+  it('items with too low of a priority do not make it in', function () {
     sample.update('a', Date.now() + 1000);
     sample.update('b', Date.now() + 2000);
-    sample.update('c', Date.now() + 0);
+    sample.update('c', Date.now());
 
     assert.deepEqual(sample.toSortedArray(), ['a', 'b']);
-  },
+  });
 });
 
-var sample;
-test('ExponentiallyDecayingSample#_rescale', {
-  before: function() {
+describe('ExponentiallyDecayingSample#_rescale', function () {
+  var sample;
+  beforeEach(function () {
     sample = new EDS({
       size: 2,
-      random: function() {
+      random: function () {
         return 1;
       }
     });
-  },
+  });
 
-  'works as expected': function() {
+  it('works as expected', function () {
     sample.update('a', Date.now() + 50 * units.MINUTES);
     sample.update('b', Date.now() + 55 * units.MINUTES);
 
@@ -119,5 +121,5 @@ test('ExponentiallyDecayingSample#_rescale', {
     assert.ok(elements[0].priority > 0);
     assert.ok(elements[1].priority < 1);
     assert.ok(elements[1].priority > 0);
-  },
+  });
 });

--- a/test/unit/util/test-ExponentiallyMovingWeightedAverage.js
+++ b/test/unit/util/test-ExponentiallyMovingWeightedAverage.js
@@ -1,12 +1,14 @@
+/*global describe, it, beforeEach, afterEach*/
+'use strict';
+
 var common = require('../../common');
-var test   = require('utest');
 var assert = require('assert');
 var units = common.measured.units;
 var EMWA = common.measured.ExponentiallyMovingWeightedAverage;
 
-test('ExponentiallyMovingWeightedAverage', {
-  'decay over several updates and ticks': function() {
-    var ewma = new EMWA(1 * units.MINUTES, 5 * units.SECONDS);
+describe('ExponentiallyMovingWeightedAverage', function () {
+  it('decay over several updates and ticks', function () {
+    var ewma = new EMWA(units.MINUTES, 5 * units.SECONDS);
 
     ewma.update(5);
     ewma.tick();
@@ -24,11 +26,12 @@ test('ExponentiallyMovingWeightedAverage', {
 
     assert.equal(ewma.rate(units.SECONDS).toFixed(3), '0.455');
 
-    for (var i = 0; i < 200; i++) {
+    var i;
+    for (i = 0; i < 200; i++) {
       ewma.update(15);
       ewma.tick();
     }
 
     assert.equal(ewma.rate(units.SECONDS).toFixed(3), '3.000');
-  },
+  });
 });

--- a/test/unit/util/test-Stopwatch.js
+++ b/test/unit/util/test-Stopwatch.js
@@ -1,46 +1,50 @@
+/*global describe, it, beforeEach, afterEach*/
+'use strict';
+
 var common    = require('../../common');
-var test      = require('utest');
 var assert    = require('assert');
 var Stopwatch = common.measured.Stopwatch;
 var sinon     = require('sinon');
 
-var watch;
-var clock;
-test('Stopwatch', {
-  before: function() {
+describe('Stopwatch', function () {
+  var watch;
+  var clock;
+  beforeEach(function () {
     clock = sinon.useFakeTimers();
-    watch = new Stopwatch({getTime: Date.now});
-  },
+    watch = new Stopwatch({getTime: function () {
+      return new Date().getTime();
+    }});
+  });
 
-  after: function() {
+  afterEach(function () {
     clock.restore();
-  },
+  });
 
-  'returns time on end': function() {
+  it('returns time on end', function () {
     clock.tick(100);
 
     var elapsed = watch.end();
     assert.equal(elapsed, 100);
-  },
+  });
 
-  'emits time on end': function() {
+  it('emits time on end', function () {
     clock.tick(20);
 
     var time;
-    watch.on('end', function(_time) {
+    watch.on('end', function (_time) {
       time = _time;
     });
 
     watch.end();
 
     assert.equal(time, 20);
-  },
+  });
 
-  'becomes useless after being ended once': function() {
+  it('becomes useless after being ended once', function () {
     clock.tick(20);
 
     var time;
-    watch.on('end', function(_time) {
+    watch.on('end', function (_time) {
       time = _time;
     });
 
@@ -50,5 +54,5 @@ test('Stopwatch', {
     time = null;
     assert.equal(watch.end(), undefined);
     assert.equal(time, null);
-  },
+  });
 });


### PR DESCRIPTION
I need this module to work on node and in browsers though browserify. The quickest way for me to run the tests on multiple browsers was to convert the test cases to Mocha and use [Mochify](https://www.npmjs.com/package/mochify) with my WebDriver setup. The current `npm test` lints, runs tests on node and phantomjs.

This PR is probably changing too much, but I thought I'd let you know anyway. I'm happy to maintain a fork and publish under a different name and would of cause link this repo and give as much credit as possible.

Obviously, I'd also help maintain this repo, in case you are happy with the changes :)

For the moment, I removed support for node < 0.10. It should be easy to support node 0.6 and 0.8 on travis by not using the new npm version ranges. The question is, does anyone care?

Please let me know your thoughts and if there's anything you'd like me to change. In case you prefer a fork, is there anything special that you want me to put in there?