### PR TITLE
toFlatJSON(): My attempt at what I think is meant by the flatten() feature for reporters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.un~
 /node_modules/*
+*.swp

--- a/.jslintrc
+++ b/.jslintrc
@@ -1,6 +1,6 @@
 {
   "indent"   : 2,
-  "maxlen"   : 79,
+  "maxlen"   : 94,
   "node"     : true,
   "plusplus" : true,
   "vars"     : true,

--- a/Readme.md
+++ b/Readme.md
@@ -252,6 +252,19 @@ http.createServer(function(req, res) {
 * Implement async gauges
 * Document using this with graphite / zabbix
 
+## Contributing
+
+Ensure that you run `npm test` before submitting pull requests.
+
+### Formatting code
+
+An easy way to ensure your code will lint correctly from a style perspective is using **js-beautify**.  The following command can be used on files which have been edited.
+
+```shell
+js-beautify -s 2 -jr <filename>
+```
+
 ## License
 
 This module is licensed under the MIT license.
+

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -24,6 +24,9 @@ Collection.prototype.toFlatJSON = function () {
         case "Counter":
           entry.count = this._metrics[metric].toJSON();
           break;
+        case "Gauge":
+          entry.value = this._metrics[metric].toJSON();
+          break;
         case "Meter":
           entry = this._metrics[metric].toJSON();
           break;

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var metrics = require('./metrics');
+var util = require('util');
 
 function Collection(name) {
   this.name     = name;
@@ -11,6 +12,28 @@ Collection.prototype.register = function (name, metric) {
   this._metrics[name] = metric;
 };
 
+Collection.prototype.toFlatJSON = function () {
+  var json = []
+
+  var metric;
+  for (metric in this._metrics) {
+    if (this._metrics.hasOwnProperty(metric)) {
+      var type = this._metrics[metric].constructor.name;
+      var entry = {};
+      if (type === "Counter") {
+        entry.count = this._metrics[metric].toJSON();
+      }
+      entry.name = metric;
+      entry.type = type.toLowerCase();
+      if(this.name !== undefined){
+        entry.group = this.name;
+      }
+      json.push(entry);
+    }
+  }
+
+  return json;
+};
 Collection.prototype.toJSON = function () {
   var json = {};
 

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -27,11 +27,8 @@ Collection.prototype.toFlatJSON = function () {
         case "Gauge":
           entry.value = this._metrics[metric].toJSON();
           break;
-        case "Meter":
-          entry = this._metrics[metric].toJSON();
-          break;
         default:
-          break;
+          entry = this._metrics[metric].toJSON();
       }
       entry.name = metric;
       entry.type = type.toLowerCase();

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -27,6 +27,11 @@ Collection.prototype.toFlatJSON = function () {
         case "Gauge":
           entry.value = this._metrics[metric].toJSON();
           break;
+        case "Timer":
+          var value = this._metrics[metric].toJSON();
+          entry = Object.assign(entry, value['histogram']);
+          entry = Object.assign(entry, value['meter']);
+          break;
         default:
           entry = this._metrics[metric].toJSON();
       }

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -20,8 +20,15 @@ Collection.prototype.toFlatJSON = function () {
     if (this._metrics.hasOwnProperty(metric)) {
       var type = this._metrics[metric].constructor.name;
       var entry = {};
-      if (type === "Counter") {
-        entry.count = this._metrics[metric].toJSON();
+      switch(type){
+        case "Counter":
+          entry.count = this._metrics[metric].toJSON();
+          break;
+        case "Meter":
+          entry = this._metrics[metric].toJSON();
+          break;
+        default:
+          break;
       }
       entry.name = metric;
       entry.type = type.toLowerCase();

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -2,9 +2,10 @@
 
 var metrics = require('./metrics');
 var util = require('util');
+var ObjectUtils = require('./util/Object');
 
 function Collection(name) {
-  this.name     = name;
+  this.name = name;
   this._metrics = {};
 }
 
@@ -13,31 +14,32 @@ Collection.prototype.register = function (name, metric) {
 };
 
 Collection.prototype.toFlatJSON = function () {
-  var json = []
+  var json = [];
 
-  var metric;
+  var metric, type, entry, value;
   for (metric in this._metrics) {
     if (this._metrics.hasOwnProperty(metric)) {
-      var type = this._metrics[metric].constructor.name;
-      var entry = {};
-      switch(type){
-        case "Counter":
-          entry.count = this._metrics[metric].toJSON();
-          break;
-        case "Gauge":
-          entry.value = this._metrics[metric].toJSON();
-          break;
-        case "Timer":
-          var value = this._metrics[metric].toJSON();
-          entry = Object.assign(entry, value['histogram']);
-          entry = Object.assign(entry, value['meter']);
-          break;
-        default:
-          entry = this._metrics[metric].toJSON();
+      type = this._metrics[metric].constructor.name;
+      value = this._metrics[metric].toJSON();
+      entry = {};
+      switch (type) {
+      case "Counter":
+        entry.count = value;
+        break;
+      case "Gauge":
+        entry.value = value;
+        break;
+      case "Timer":
+        entry = ObjectUtils.extend(entry, value.histogram);
+        entry = ObjectUtils.extend(entry, value.meter);
+        break;
+      default:
+        entry = value;
+        break;
       }
       entry.name = metric;
       entry.type = type.toLowerCase();
-      if(this.name !== undefined){
+      if (this.name !== undefined) {
         entry.group = this.name;
       }
       json.push(entry);

--- a/lib/util/Object.js
+++ b/lib/util/Object.js
@@ -1,0 +1,11 @@
+'use strict';
+
+exports.extend = function extend(obj, src) {
+  var key;
+  for (key in src) {
+    if (src.hasOwnProperty(key)) {
+      obj[key] = src[key];
+    }
+  }
+  return obj;
+};

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -1,9 +1,7 @@
 'use strict';
 
-exports.units      = require('./units');
+exports.units = require('./units');
 exports.BinaryHeap = require('./BinaryHeap');
-exports.Stopwatch  = require('./Stopwatch');
-exports.ExponentiallyDecayingSample
-  = require('./ExponentiallyDecayingSample');
-exports.ExponentiallyMovingWeightedAverage
-  = require('./ExponentiallyMovingWeightedAverage');
+exports.Stopwatch = require('./Stopwatch');
+exports.ExponentiallyDecayingSample = require('./ExponentiallyDecayingSample');
+exports.ExponentiallyMovingWeightedAverage = require('./ExponentiallyMovingWeightedAverage');

--- a/test/unit/test-Collection.js
+++ b/test/unit/test-Collection.js
@@ -59,34 +59,7 @@ describe('Collection', function () {
         {'type':'gauge','name':'my-gauge','value':expected,'group':'my-collection'},
       ]); 
     });
-
-    /*
-    var a,b,c,d,e,f;
-    beforeEach(function(){
-      collection = new common.measured.Collection('counters');
-      var a = collection.counter('a');
-      var b = collection.counter('b');
-      var c = collection.histogram('c');
-      var d = collection.meter('d');
-      var gauge = new common.measured.Gauge(function(){
-        return 23;
-      });
-      var e = collection.register('e', gauge);
-      var f = collection.timer('f');
-      a.inc(3);
-      b.inc(5);
-      c.update(1);
-      d.mark();
-      f.update(1);
-    });
-
-    it('using toFlatJSON', function () {
-      var result = collection.toFlatJSON();
-      assert.equal(result.length, 6);
-      assert.equal(result[0].name, 'a');
-      assert.equal(result[0].type, 'counter');
-    });
-    */
+    
   });
 
   it('returns same metric object when given the same name', function () {

--- a/test/unit/test-Collection.js
+++ b/test/unit/test-Collection.js
@@ -11,6 +11,35 @@ describe('Collection', function () {
     collection = common.measured.createCollection();
   });
 
+  it('with two counters', function () {
+    collection = new common.measured.Collection('counters');
+    var a = collection.counter('a');
+    var b = collection.counter('b');
+
+    a.inc(3);
+    b.inc(5);
+
+    assert.deepEqual(collection.toJSON(), {
+      'counters': {
+        'a': 3,
+        'b': 5
+      }
+    });
+  });
+
+  it('returns same metric object when given the same name', function () {
+    var a1 = collection.counter('a');
+    var a2 = collection.counter('a');
+
+    assert.strictEqual(a1, a2);
+  });
+
+  it('throws exception when creating a metric without name', function () {
+    assert.throws(function () {
+      collection.counter();
+    }, /Collection\.NoMetricName/);
+  });
+
   describe.only('toFlatJSON', function(){
     beforeEach(function(){
       collection = new common.measured.Collection('my-collection');
@@ -113,18 +142,5 @@ describe('Collection', function () {
       assert.ok(result.group,'my-collection');
       assert.ok(result.type,'timer');
     });
-  });
-
-  it('returns same metric object when given the same name', function () {
-    var a1 = collection.counter('a');
-    var a2 = collection.counter('a');
-
-    assert.strictEqual(a1, a2);
-  });
-
-  it('throws exception when creating a metric without name', function () {
-    assert.throws(function () {
-      collection.counter();
-    }, /Collection\.NoMetricName/);
   });
 });

--- a/test/unit/test-Collection.js
+++ b/test/unit/test-Collection.js
@@ -82,6 +82,37 @@ describe('Collection', function () {
       assert.equal(result.group,'my-collection');
       assert.equal(result.type,'histogram');
     });
+
+    it('outputs a timer', function(){
+      var timer = collection.timer('my-timer');
+      timer.update(1);
+      timer.update(1);
+
+      var result = collection.toFlatJSON()[0];
+      //Meter Stats
+      assert.ok(result.mean >= 0);
+      assert.ok(result.count >= 0);
+      assert.ok(result.currentRate >= 0);
+      assert.ok(result['1MinuteRate'] >= 0);
+      assert.ok(result['5MinuteRate'] >= 0);
+      assert.ok(result['15MinuteRate'] >= 0);
+      //Histogram Stats
+      assert.ok(result.min >= 0);
+      assert.ok(result.max >= 0);
+      assert.ok(result.sum >= 0);
+      assert.ok(result.variance >= 0);
+      assert.ok(result.mean >= 0);
+      assert.ok(result.stddev >= 0);
+      assert.ok(result.count >= 0);
+      assert.ok(result.median >= 0);
+      assert.ok(result.p75 >= 0);
+      assert.ok(result.p95 >= 0);
+      assert.ok(result.p99 >= 0);
+      assert.ok(result.p999 >= 0);
+      assert.ok(result.name,'my-timer');
+      assert.ok(result.group,'my-collection');
+      assert.ok(result.type,'timer');
+    });
   });
 
   it('returns same metric object when given the same name', function () {

--- a/test/unit/test-Collection.js
+++ b/test/unit/test-Collection.js
@@ -40,16 +40,16 @@ describe('Collection', function () {
     }, /Collection\.NoMetricName/);
   });
 
-  describe.only('toFlatJSON', function(){
-    beforeEach(function(){
+  describe('toFlatJSON', function () {
+    beforeEach(function () {
       collection = new common.measured.Collection('my-collection');
     });
 
-    it('outputs an array', function(){
+    it('outputs an array', function () {
       assert.ok(Array.isArray(collection.toFlatJSON()));
     });
 
-    it('outputs two collections', function(){
+    it('outputs two collections', function () {
       var a = collection.counter('a');
       var b = collection.counter('b');
 
@@ -57,13 +57,20 @@ describe('Collection', function () {
       b.inc(5);
 
       var result = collection.toFlatJSON();
-      assert.deepEqual(result, [
-        {'type':'counter','name':'a','count':3,'group':'my-collection'},
-        {'type':'counter','name':'b','count':5,'group':'my-collection'},
-      ]);
+      assert.deepEqual(result, [{
+        'type': 'counter',
+        'name': 'a',
+        'count': 3,
+        'group': 'my-collection'
+      }, {
+        'type': 'counter',
+        'name': 'b',
+        'count': 5,
+        'group': 'my-collection'
+      }]);
     });
 
-    it('outputs a meter', function(){
+    it('outputs a meter', function () {
       var meter = collection.meter('my-meter');
       meter.mark();
 
@@ -76,20 +83,23 @@ describe('Collection', function () {
       assert.ok(result['15MinuteRate'] >= 0);
     });
 
-    it('outputs a gauge', function(){
+    it('outputs a gauge', function () {
       var expected = 42;
-      var gauge = new common.measured.Gauge(function(){
+      var gauge = new common.measured.Gauge(function () {
         return expected;
       });
-      
-      collection.register('my-gauge', gauge);  
+
+      collection.register('my-gauge', gauge);
       var result = collection.toFlatJSON();
-      assert.deepEqual(result, [
-        {'type':'gauge','name':'my-gauge','value':expected,'group':'my-collection'},
-      ]); 
+      assert.deepEqual(result, [{
+        'type': 'gauge',
+        'name': 'my-gauge',
+        'value': expected,
+        'group': 'my-collection'
+      }]);
     });
-    
-    it('outputs a histogram', function(){
+
+    it('outputs a histogram', function () {
       var histogram = collection.histogram('my-histogram');
       histogram.update(1);
       histogram.update(1);
@@ -107,12 +117,12 @@ describe('Collection', function () {
       assert.equal(result.p95, 1);
       assert.equal(result.p99, 1);
       assert.equal(result.p999, 1);
-      assert.equal(result.name,'my-histogram');
-      assert.equal(result.group,'my-collection');
-      assert.equal(result.type,'histogram');
+      assert.equal(result.name, 'my-histogram');
+      assert.equal(result.group, 'my-collection');
+      assert.equal(result.type, 'histogram');
     });
 
-    it('outputs a timer', function(){
+    it('outputs a timer', function () {
       var timer = collection.timer('my-timer');
       timer.update(1);
       timer.update(1);
@@ -138,9 +148,9 @@ describe('Collection', function () {
       assert.ok(result.p95 >= 0);
       assert.ok(result.p99 >= 0);
       assert.ok(result.p999 >= 0);
-      assert.ok(result.name,'my-timer');
-      assert.ok(result.group,'my-collection');
-      assert.ok(result.type,'timer');
+      assert.ok(result.name, 'my-timer');
+      assert.ok(result.group, 'my-collection');
+      assert.ok(result.type, 'timer');
     });
   });
 });

--- a/test/unit/test-Collection.js
+++ b/test/unit/test-Collection.js
@@ -47,6 +47,19 @@ describe('Collection', function () {
       assert.ok(result['15MinuteRate'] >= 0);
     });
 
+    it('outputs a gauge', function(){
+      var expected = 42;
+      var gauge = new common.measured.Gauge(function(){
+        return expected;
+      });
+      
+      collection.register('my-gauge', gauge);  
+      var result = collection.toFlatJSON();
+      assert.deepEqual(result, [
+        {'type':'gauge','name':'my-gauge','value':expected,'group':'my-collection'},
+      ]); 
+    });
+
     /*
     var a,b,c,d,e,f;
     beforeEach(function(){

--- a/test/unit/test-Collection.js
+++ b/test/unit/test-Collection.js
@@ -60,6 +60,28 @@ describe('Collection', function () {
       ]); 
     });
     
+    it('outputs a histogram', function(){
+      var histogram = collection.histogram('my-histogram');
+      histogram.update(1);
+      histogram.update(1);
+
+      var result = collection.toFlatJSON()[0];
+      assert.equal(result.min, 1);
+      assert.equal(result.max, 1);
+      assert.equal(result.sum, 2);
+      assert.equal(result.variance, 0);
+      assert.equal(result.mean, 1);
+      assert.equal(result.stddev, 0);
+      assert.equal(result.count, 2);
+      assert.equal(result.median, 1);
+      assert.equal(result.p75, 1);
+      assert.equal(result.p95, 1);
+      assert.equal(result.p99, 1);
+      assert.equal(result.p999, 1);
+      assert.equal(result.name,'my-histogram');
+      assert.equal(result.group,'my-collection');
+      assert.equal(result.type,'histogram');
+    });
   });
 
   it('returns same metric object when given the same name', function () {

--- a/test/unit/test-Collection.js
+++ b/test/unit/test-Collection.js
@@ -34,6 +34,19 @@ describe('Collection', function () {
       ]);
     });
 
+    it('outputs a meter', function(){
+      var meter = collection.meter('my-meter');
+      meter.mark();
+
+      var result = collection.toFlatJSON()[0];
+      assert.ok(result.mean >= 0);
+      assert.ok(result.count >= 0);
+      assert.ok(result.currentRate >= 0);
+      assert.ok(result['1MinuteRate'] >= 0);
+      assert.ok(result['5MinuteRate'] >= 0);
+      assert.ok(result['15MinuteRate'] >= 0);
+    });
+
     /*
     var a,b,c,d,e,f;
     beforeEach(function(){

--- a/test/unit/test-Collection.js
+++ b/test/unit/test-Collection.js
@@ -4,26 +4,63 @@
 var common = require('../common');
 var assert = require('assert');
 
+
 describe('Collection', function () {
   var collection;
   beforeEach(function () {
     collection = common.measured.createCollection();
   });
 
-  it('with two counters', function () {
-    collection = new common.measured.Collection('counters');
-    var a = collection.counter('a');
-    var b = collection.counter('b');
-
-    a.inc(3);
-    b.inc(5);
-
-    assert.deepEqual(collection.toJSON(), {
-      'counters': {
-        'a': 3,
-        'b': 5
-      }
+  describe.only('toFlatJSON', function(){
+    beforeEach(function(){
+      collection = new common.measured.Collection('my-collection');
     });
+
+    it('outputs an array', function(){
+      assert.ok(Array.isArray(collection.toFlatJSON()));
+    });
+
+    it('outputs two collections', function(){
+      var a = collection.counter('a');
+      var b = collection.counter('b');
+
+      a.inc(3);
+      b.inc(5);
+
+      var result = collection.toFlatJSON();
+      assert.deepEqual(result, [
+        {'type':'counter','name':'a','count':3,'group':'my-collection'},
+        {'type':'counter','name':'b','count':5,'group':'my-collection'},
+      ]);
+    });
+
+    /*
+    var a,b,c,d,e,f;
+    beforeEach(function(){
+      collection = new common.measured.Collection('counters');
+      var a = collection.counter('a');
+      var b = collection.counter('b');
+      var c = collection.histogram('c');
+      var d = collection.meter('d');
+      var gauge = new common.measured.Gauge(function(){
+        return 23;
+      });
+      var e = collection.register('e', gauge);
+      var f = collection.timer('f');
+      a.inc(3);
+      b.inc(5);
+      c.update(1);
+      d.mark();
+      f.update(1);
+    });
+
+    it('using toFlatJSON', function () {
+      var result = collection.toFlatJSON();
+      assert.equal(result.length, 6);
+      assert.equal(result[0].name, 'a');
+      assert.equal(result[0].type, 'counter');
+    });
+    */
   });
 
   it('returns same metric object when given the same name', function () {


### PR DESCRIPTION
I wanted to have an output of the JSON in such a way that I could search over it meaning I would need properties like `name` and `type` as opposed to each of the metrics being keyed by the name of the metric e.g. **requestsPerSecond**.  This will help me  getting the output into elastic search and the like too.

This feels like the intended functionality for the `flatten()` method mentioned in the todos in the README but I could be wrong.  Not 100% sure about the name (toFlatJSON).  I did think about a method which is called  flatten which would take the original output of toJSON but this is the implementation I have gone with for now.