### PR TITLE
Meter supports overriding m1Rate, m5Rate & m15Rate via properties

### DIFF
--- a/lib/metrics/Meter.js
+++ b/lib/metrics/Meter.js
@@ -13,9 +13,12 @@ function Meter(properties) {
     this._getTime = properties.getTime;
   }
 
-  this._m1Rate     = new EWMA(units.MINUTES, this._tickInterval);
-  this._m5Rate     = new EWMA(5 * units.MINUTES, this._tickInterval);
-  this._m15Rate    = new EWMA(15 * units.MINUTES, this._tickInterval);
+  this._m1Rate     = properties.m1Rate ||
+    new EWMA(units.MINUTES, this._tickInterval);
+  this._m5Rate     = properties.m5Rate ||
+    new EWMA(5 * units.MINUTES, this._tickInterval);
+  this._m15Rate    = properties.m15Rate ||
+    new EWMA(15 * units.MINUTES, this._tickInterval);
   this._count      = 0;
   this._currentSum = 0;
   this._startTime = this._getTime();

--- a/test/unit/metrics/test-Meter.js
+++ b/test/unit/metrics/test-Meter.js
@@ -31,6 +31,20 @@ describe('Meter', function () {
     });
   });
 
+  it('supports rates override from opts', function () {
+    var rate = sinon.stub().returns(666);
+    var properties = {
+      m1Rate: {rate: rate},
+      m5Rate: {rate: rate},
+      m15Rate: {rate: rate}
+    };
+    var json = new common.measured.Meter(properties).toJSON();
+
+    assert.equal(json['1MinuteRate'].toFixed(0), '666');
+    assert.equal(json['5MinuteRate'].toFixed(0), '666');
+    assert.equal(json['15MinuteRate'].toFixed(0), '666');
+  });
+
   it('decay over two marks and ticks', function () {
     meter.mark(5);
     meter._tick();


### PR DESCRIPTION
@felixge The same idea you [have](https://github.com/felixge/node-measured/blob/master/lib/metrics/Histogram.js#L8) already in `Histogram`, but for `Meter`.
